### PR TITLE
fix cookie ga management + set compatibility with guzzle 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,28 @@ Google Analytics Measurement Protocol Package for Symfony2. Supports all GA Meas
 Open a command console, enter your project directory and execute the following command to download the latest version of this bundle:
 
 ``` bash
-$ composer require fourlabs/gamp-bundle dev-master
+$ composer require fourlabs/gamp-bundle
 ```
 
 This command requires you to have Composer installed globally, as explained in the [installation chapter](https://getcomposer.org/doc/00-intro.md) of the Composer documentation.
+
+### Compatibility with Guzzle 5 and 6
+
+If you are using PHP 5.5 or above and Guzzle 6 then:
+
+    {
+        "require": {
+            "fourlabs/gamp-bundle": "^2.0"
+        }
+    }
+
+Or if you are using PHP 5.4 or above and Guzzle 5 then:
+
+    {
+        "require": {
+            "fourlabs/gamp-bundle": "^1.1"
+        }
+    }
 
 ### Enable the Bundle
 
@@ -58,6 +76,15 @@ Refer to [the library's documentation][2] for other remaining methods and exampl
 [2]: https://github.com/theiconic/php-ga-measurement-protocol#usage
 
 ### Configuration
+
+Example of configuration in `app/config.yml`:
+
+    four_labs_gamp:
+        protocol_version: 1
+        tracking_id: UA-XXXXXXX-X
+        use_ssl: true
+        anonymize_ip: false
+        async_requests: true
 
 Set your Google Analytics Tracking / Web Property ID in `tracking_id` key **[REQUIRED]**
 

--- a/Service/AnalyticsFactory.php
+++ b/Service/AnalyticsFactory.php
@@ -25,9 +25,10 @@ class AnalyticsFactory
             ;
 
             // set clientId from ga cookie if exists
-            $clientId = $this->parseCookie($request->cookies->get('_ga', null))['cid'];
-            if(!empty($clientId))
-                $analytics->setClientId();
+            if($request->cookies->has('_ga')){
+                $clientId = $this->parseCookie($request->cookies->get('_ga'))['cid'];
+                $analytics->setClientId($clientId);
+            }
 
             // Also, you can set clientID later like this:
             // $this->get('gamp.analytics')->setClientId($user->getId());
@@ -44,7 +45,7 @@ class AnalyticsFactory
      */
     public function parseCookie($cookie = null)
     {
-        // If _ga cookie is null try to use the default _ga cookie
+        // If $cookie is null try to use the default _ga cookie
         if(empty($cookie)){
             $cookie = $_COOKIE["_ga"];
         }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "fourlabs/gamp-bundle",
+    "version": "1.1.0",
     "type": "symfony-bundle",
     "description": "Google Analytics Measurement Protocol Package for Symfony2",
     "keywords": ["google", "analytics", "gamp", "tracking"],
@@ -14,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "theiconic/php-ga-measurement-protocol": "^2.0",
+        "theiconic/php-ga-measurement-protocol": "^1.1",
         "symfony/framework-bundle": "~2.4 || ~3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.4",
         "theiconic/php-ga-measurement-protocol": "^1.1",
         "symfony/framework-bundle": "~2.4 || ~3.0"
     },


### PR DESCRIPTION
Hello,
I create a fork of your bundle and I manage to handle properly the cookie issue #1 and the take into account Guzzle 5 dependencies #2 

You can find in my fork repository 2 tags (1.1.0 and 2.0.0):

* 1.1.0 is for "theiconic/php-ga-measurement-protocol": "^1.1" with Guzzle 5
* 2.0.0 is for "theiconic/php-ga-measurement-protocol": "^2.0" with Guzzle 6

Thank you in advance for the merge!

If you have any question don't hesitate!