### PR TITLE
Allow AnalyticsFactory to be public/shared and injected in other services

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,18 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="gamp.analytics.class">FourLabs\GampBundle\Service\AnalyticsFactory</parameter>
     </parameters>
-
     <services>
-        <service id="gamp.analytics.factory" class="%gamp.analytics.class%" public="false" />
-
-        <service id="gamp.analytics" class="TheIconic\Tracking\GoogleAnalytics\Analytics" shared="false">
-            <factory service="gamp.analytics.factory" method="createAnalytics" />
-            <argument type="service" id="request_stack" />
+        <service id="gamp.analytics.factory" class="%gamp.analytics.class%">
+            <argument type="service" id="request_stack"/>
             <argument>%gamp.protocol_version%</argument>
             <argument>%gamp.tracking_id%</argument>
             <argument>%gamp.use_ssl%</argument>
@@ -20,6 +15,9 @@
             <argument>%gamp.async_requests%</argument>
             <argument>%kernel.debug%</argument>
             <argument>%gamp.sandbox%</argument>
+        </service>
+        <service id="gamp.analytics" class="TheIconic\Tracking\GoogleAnalytics\Analytics" shared="false">
+            <factory service="gamp.analytics.factory" method="createAnalytics"/>
         </service>
     </services>
 </container>

--- a/Service/AnalyticsFactory.php
+++ b/Service/AnalyticsFactory.php
@@ -5,11 +5,6 @@ namespace FourLabs\GampBundle\Service;
 use Symfony\Component\HttpFoundation\RequestStack;
 use TheIconic\Tracking\GoogleAnalytics\Analytics;
 
-/**
- * Class AnalyticsFactory
- *
- * @author "Emmanuel BALLERY" <emmanuel.ballery@gmail.com>
- */
 class AnalyticsFactory
 {
     /**
@@ -75,8 +70,6 @@ class AnalyticsFactory
     }
 
     /**
-     * Create analytics
-     *
      * @return Analytics
      */
     public function createAnalytics()
@@ -108,7 +101,7 @@ class AnalyticsFactory
 
     /**
      * Parse the GA Cookie and return data as an array.
-     * Example of GA cookie: _ga:GA1.2.492973748.1449824416
+     * Example of GA cookie: _ga:GA1.2.492973748.1449824416.
      *
      * @param $cookie
      *

--- a/Tests/AnalyticsFactoryTest.php
+++ b/Tests/AnalyticsFactoryTest.php
@@ -16,14 +16,14 @@ final class AnalyticsFactoryTest extends TestCase
     protected $factory;
 
     /**
-     * @var array
+     * @var RequestStack
      */
-    protected $parameters;
+    protected $requestStack;
 
     protected function setUp()
     {
-        $this->factory = new AnalyticsFactory();
-        $this->parameters = [new RequestStack(), 1, 'UA-XXXXXXXX-X', true, false, true, true, false];
+        $this->requestStack = new RequestStack();
+        $this->factory = new AnalyticsFactory($this->requestStack, 1, 'UA-XXXXXXXX-X', true, false, true, true, false);
     }
 
     /**
@@ -31,7 +31,7 @@ final class AnalyticsFactoryTest extends TestCase
      */
     private function callFactory()
     {
-        return call_user_func_array([$this->factory, 'createAnalytics'], $this->parameters);
+        return $this->factory->createAnalytics();
     }
 
     public function testNoRequest()
@@ -43,7 +43,7 @@ final class AnalyticsFactoryTest extends TestCase
 
     public function testEmptyRequest()
     {
-        $this->parameters[0]->push(Request::create(''));
+        $this->requestStack->push(Request::create(''));
 
         $analytics = $this->callFactory();
 
@@ -61,7 +61,7 @@ final class AnalyticsFactoryTest extends TestCase
 
     public function testGaCookie()
     {
-        $this->parameters[0]->push(Request::create('', 'GET', [], ['_ga' => 'GA1.2.1792370315.1501194811']));
+        $this->requestStack->push(Request::create('', 'GET', [], ['_ga' => 'GA1.2.1792370315.1501194811']));
 
         $analytics = $this->callFactory();
 
@@ -75,7 +75,7 @@ final class AnalyticsFactoryTest extends TestCase
 
         $request = Request::create('');
         $request->headers->set('User-Agent', $userAgentString);
-        $this->parameters[0]->push($request);
+        $this->requestStack->push($request);
 
         $analytics = $this->callFactory();
 


### PR DESCRIPTION
Hi!

I updated the `AnalyticsFactory` to be able to inject it in my services/create multiple analytics without requiring the entire container and calling `$container->get('gamp.analytics')` each time. This way, I can simply create multiple Analytics like this :

```php
use FourLabs\GampBundle\Service\AnalyticsFactory;

class Stats
{
    /** @var AnalyticsFactory */
    private $analyticsFactory;

    public function __construct(AnalyticsFactory $analyticsFactory)
    {
        $this->analyticsFactory = $analyticsFactory;
    }

    public function doSomething()
    {
        $analytics1 = $this->analyticsFactory->createAnalytics();
        // ...
        $analytics2 = $this->analyticsFactory->createAnalytics();
        // ...
    }
}
```

Could you take a look and tell me what you think.

Thanks!