### PR TITLE
fix root node deprecation in symfony/config >= 4.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,8 +12,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('four_labs_gamp');
+        $treeBuilder = new TreeBuilder('four_labs_gamp');
+        $rootNode = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('four_labs_gamp');
 
         $rootNode
             ->children()


### PR DESCRIPTION
Add a backward compatible fix for the deprecation warning "A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0." (discussed in https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes)

This is a fix for issue #23 